### PR TITLE
Fix JSON freezing in Python 3

### DIFF
--- a/datafreeze/format/fjson.py
+++ b/datafreeze/format/fjson.py
@@ -44,7 +44,7 @@ class JSONSerializer(Serializer):
 
             if self.fileobj is None:
                 if PY3:  # pragma: no cover
-                    fh = open(path, 'w', encoding='utf8')
+                    fh = open(path, 'wb', encoding='utf8')
                 else:
                     fh = open(path, 'wb')
             else:

--- a/datafreeze/format/fjson.py
+++ b/datafreeze/format/fjson.py
@@ -58,6 +58,9 @@ class JSONSerializer(Serializer):
             if callback:
                 data = "%s && %s(%s);" % (callback, callback, data)
 
-            fh.write(data)
+            if PY3:
+                fh.write(bytes(data, encoding='utf8'))
+            else:
+                fh.write(data)
             if self.fileobj is None:
                 fh.close()

--- a/datafreeze/format/fjson.py
+++ b/datafreeze/format/fjson.py
@@ -43,10 +43,7 @@ class JSONSerializer(Serializer):
             result = self.wrap(result)
 
             if self.fileobj is None:
-                if PY3:  # pragma: no cover
-                    fh = open(path, 'wb', encoding='utf8')
-                else:
-                    fh = open(path, 'wb')
+                fh = open(path, 'wb')
             else:
                 fh = self.fileobj
 


### PR DESCRIPTION
Was running into an issue exporting JSON files in Python 3. 
https://github.com/pudo/dataset/issues/227

Seems like this fixes it. https://github.com/CTFd/CTFd relies on dataset for database exporting capabilities so it would be nice for this to also come with a new release on PyPI. 


